### PR TITLE
Update build.gradle to disable standard jar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
+jar {
+    enabled = false
+}
+
 shadowJar {
     archiveFileName = 'hairypawter.jar'
 }


### PR DESCRIPTION
This short pull request involves a small update to the build.gradle file to disable the standard jar task.

This ensures that when `./gradlew build` is run, the standard `tp.jar` file without any dependencies bundled is not created. This helps to avoid confusion for developers.