### PR TITLE
Update photo path and associated commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Hairy Pawter is designed for pet groomers who:
 
 ## Example Commands
 
-- `add n/Bella Tan p/91234567 e/bella@email.com a/123 Clementi Ave 3`
-- `edit 1 p/98765432`
-- `delete 2`
+- `addClient n/Bella Tan p/91234567 e/bella@email.com a/123 Clementi Ave 3`
+- `editClient 1 p/98765432`
+- `deletePet 2`
 - `find Bella`
 - `list`
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -619,7 +619,7 @@ testers are expected to do more *exploratory* testing.
    1. Other correct commands to try: Case-insensitive, alias `ec`, reordered fields, missing fields<br>
       Expected: Similar to previous.
 
-   1. Test case: `editClient 1 p/123`, where there already is a client with phone number 123<br>
+   1. Test case: `editClient 1 p/123`, where there already is a client with phone number 123 that is not in index 1<br>
       Expected: No change in the list. Error details shown in the status message.
 
    1. Other incorrect commands to try: `editClient`, repeat parameters<br>

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -619,7 +619,7 @@ testers are expected to do more *exploratory* testing.
    1. Other correct commands to try: Case-insensitive, alias `ec`, reordered fields, missing fields<br>
       Expected: Similar to previous.
 
-   1. Test case: `editClient p/123`, where there already is a client with phone number 123<br>
+   1. Test case: `editClient 1 p/123`, where there already is a client with phone number 123<br>
       Expected: No change in the list. Error details shown in the status message.
 
    1. Other incorrect commands to try: `editClient`, repeat parameters<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -49,10 +49,14 @@ so that after grooming a pet, you can quickly find the details of the owner and 
     * Linux users can try `Ctrl` + `Alt` + `T`.
 
 6. In the command terminal, enter the command `cd PATH` where PATH is the location of the _home folder_. (e.g. `cd C:\Users\jeff\Desktop\HairyPawter\`)
+    
     * You can right click on the _home folder_ and select the option most similar to `Copy as path`, then paste it after `cd `.
 
-7. In the command terminal, enter the command `java -jar hairypawter.jar` to start the app.<br>
+
+7. In the command terminal, enter the command `java -jar hairypawter.jar` to start the app.
+
     * Once the app starts, you can ignore the rest of the activity on the command terminal. Closing it will close the app.
+
 </box>
 
 <img src="images/Ui.png" class="app-screenshot" alt="Ui">
@@ -110,7 +114,7 @@ Examples:
 * `addClient n/Betsy Crowe t/friend e/betsycrowe@example.com a/Crown street p/1234567`
 
 Remarks:
-The new client may not be shown if there is a `find` condition that it does not satisfy.
+The new client may not be shown if there is an active `find` condition that it does not satisfy.
 If this happens, use `list` to show all clients.
 
 Optional values will appear as `-`.
@@ -132,23 +136,29 @@ Registers a new pet of a client. The name of the pet and the **phone number of t
 
 Note: Pets can only be added after their owner has been added.
 
-Format: `addPet n/NAME p/PHONE [s/SPECIES] [b/BREED] [nt/NOTES] [ph/PHOTO]`
+Format: `addPet n/NAME p/PHONE [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]`
 
 Examples:
 * `addPet n/Snowy p/0000 s/Dog b/Wire Fox Terrier (White)`
 * `addPet n/Meowy p/123456`
+* `addPet n/Doggy p/81234567 pic/doggy.png`
 
 Remarks:
 Optional values will appear as `Unknown` or `None`.
 
-**Using `[nt/NOTES]` to your advantage:**<br>
+<box type="info" seamless>
+
+#### **More about `[pic/PICTURE]`:**<br>
+
+* Locate the auto-generated photos subdirectory `[hairypawter.jar file location]/data/photos/` (if it has not been generated yet, run any command that adds or deletes an entry first)
+* Copy a photo you wish to add into that subdirectory, and take note of its filename
+* Include this filename after the `pic/` tag when adding a photo using the `addPet` or `editPet` command (eg. `pic/doggy.png`)
+* You may choose to organise the images within your `data/photos/` subdirectory into subfolders. In that case, take note that the filepath you are required to provide will be `[subdirectory name]/[image filename]`
+
+#### **Using `[nt/NOTES]` to your advantage:**<br>
 
 * `[nt/NOTES]` exists to record down important information about the pet. This can be identifying information
 like leash colour, or allergies and quirks of the pet. Use this flexibly!
-
-**More about `[ph/PHOTO]`:**<br>
-
-* Paste a photo path here. In your file explorer, you can right-click on your photo and select `Copy as path` or `Copy as Pathname`, then paste into this field with `Ctrl` + `v`.
 
 </box>
 
@@ -169,8 +179,7 @@ Edits an existing client.
 * Edits the client at the specified `POSITION`. The `POSITION` refers to the number shown next to the client.
 * Specified values will override old values.
 * Editing tags will clear previous tags.
-* You can remove a client’s tags by typing `t/` without
-    specifying any tags after it.
+* You can remove a client’s tags by typing `t/` without specifying any tags after it.
 
 Format: `editClient POSITION [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * You need to edit at least one of the optional values.
@@ -187,13 +196,22 @@ Edits an existing pet.
 
 * Edits the pet at the specified `POSITION`. The `POSITION` refers to the number shown next to the pet.​
 * Specified values will override old values.
+* You can remove a pet's picture by typing `pic/` without specifying any filename after it.
 
-Format: `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED]​ [nt/NOTES] [ph/PHOTO]`
+Format: `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED]​ [nt/NOTES] [pic/PICTURE]`
 * You need to edit at least one of the optional values.
 
 Examples:
 *  `editPet 1 s/cat` Edits the species of the pet in `POSITION` 1.
 *  `editPet 2 n/Gunner` Changes the name of the pet in `POSITION` 2 to `Gunner`.
+
+<box type="info" seamless>
+
+Click [here](#more-about-picpicture) for more details on how to use the picture `pic/` tag!
+
+Click [here](#using-ntnotes-to-your-advantage) to see how you could use the notes `nt/` tag to your advantage!
+
+</box>
 
 <br><br>
 
@@ -326,12 +344,12 @@ One way to do this is to close the app and manually reorder the clients in the d
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 **AddClient** | `addClient p/PHONE [n/NAME] [e/EMAIL] [a/ADDRESS] [t/TAG]…​` <br> e.g., `addClient n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend`
-**AddPet** | `addPet n/NAME p/PHONE​ [s/SPECIES] [b/BREED] [nt/NOTES] [ph/PHOTO]` <br> e.g., `addPet n/Meowy p/22224444`
+**AddPet** | `addPet n/NAME p/PHONE​ [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]` <br> e.g., `addPet n/Meowy p/22224444`
 **Clear**  | `clear`
 **DeleteClient** | `deleteClient POSITION`<br> e.g., `deleteClient 3`
 **DeletePet** | `deletePet POSITION`<br> e.g., `deletePet 1`
 **EditClient**   | `editClient POSITION [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editClient 2 n/James Lee e/jameslee@example.com`
-**EditPet**   | `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED] [nt/NOTES] [ph/PHOTO]`<br> e.g.,`editPet 2 n/Pongo`
+**EditPet**   | `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]`<br> e.g.,`editPet 2 n/Pongo`
 **Exit**   | `exit`
 **Find**   | `find KEYWORD...`<br> e.g., `find James dog`
 **Help**   | `help`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,7 +153,7 @@ Optional values will appear as `Unknown` or `None`.
 * Locate the auto-generated photos subdirectory `[hairypawter.jar file location]/data/photos/` (if it has not been generated yet, run any command that adds or deletes an entry first)
 * Copy a photo you wish to add into that subdirectory, and take note of its filename
 * Include this filename after the `pic/` tag when adding a photo using the `addPet` or `editPet` command (eg. `pic/doggy.png`)
-* You may choose to organise the images within your `data/photos/` subdirectory into subfolders. In that case, take note that the filepath you are required to provide will be `[subdirectory name]/[image filename]`
+* You may choose to organise the images within your `data/photos/` subdirectory into subfolders. In that case, take note that the filepath you are required to provide will be `[subdirectory name]/[image filename]`. Be careful not to end the subdirectory name with any other tag name (eg. the filepath `subfolder nt/pet.png` is not allowed)
 
 #### **Using `[nt/NOTES]` to your advantage:**<br>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -154,6 +154,10 @@ Optional values will appear as `Unknown` or `None`.
 * Copy a photo you wish to add into that subdirectory, and take note of its filename
 * Include this filename after the `pic/` tag when adding a photo using the `addPet` or `editPet` command (eg. `pic/doggy.png`)
 * You may choose to organise the images within your `data/photos/` subdirectory into subfolders. In that case, take note that the filepath you are required to provide will be `[subdirectory name]/[image filename]`. Be careful not to end the subdirectory name with any other tag name (eg. the filepath `subfolder nt/pet.png` is not allowed)
+* A picture will show as the placeholder pawprint icon in 2 cases:
+  1. No picture has been added to the pet.
+  1. A valid picture was initially added, but was later unable to be located (either due to the picture being deleted or due to the filepath being manually edited to an invalid filepath in the JSON file after the initial adding)
+  * If this happens, try to re-add the photo with the `editPet` command with the corrected filename and filepath
 
 #### **Using `[nt/NOTES]` to your advantage:**<br>
 
@@ -306,6 +310,7 @@ It is possible, but not recommended, to update data directly by editing that dat
 **Caution:**
 If your changes to the data file makes its format invalid, the entire file will be discarded the next time the app is opened.  Hence, it is recommended to take a backup of the file before editing it.<br>
 Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+
 </box>
 
 <br><br>

--- a/src/main/java/seedu/address/commons/util/AppUtil.java
+++ b/src/main/java/seedu/address/commons/util/AppUtil.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.LogsCenter;
 public class AppUtil {
 
     private static final Logger logger = LogsCenter.getLogger(AppUtil.class);
+    private static final Path DATA_PHOTOS_DIR = Paths.get("data", "photos");
 
     /**
     * Loads an image from the specified path. If the image cannot be loaded, a
@@ -40,6 +41,9 @@ public class AppUtil {
             } else {
                 // Try as a filesystem path (handles normalized forward-slash paths on all OSes)
                 Path photoPath = Paths.get(imagePath);
+                if (!photoPath.isAbsolute()) {
+                    photoPath = DATA_PHOTOS_DIR.resolve(photoPath).normalize();
+                }
                 if (!Files.exists(photoPath) || !Files.isRegularFile(photoPath)) {
                     throw new IOException("Image file not found: " + imagePath);
                 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,5 +1,7 @@
 package seedu.address.logic;
 
+import static seedu.address.logic.parser.CliSyntax.PLACEHOLDER_IMAGE_PATH;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -17,8 +19,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The client index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d clients listed!";
-    public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following single-valued field(s): ";
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -26,8 +27,7 @@ public class Messages {
     public static String getErrorMessageForDuplicatePrefixes(Prefix... duplicatePrefixes) {
         assert duplicatePrefixes.length > 0;
 
-        Set<String> duplicateFields =
-                Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
+        Set<String> duplicateFields = Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
     }
@@ -51,6 +51,7 @@ public class Messages {
 
     /**
      * Formats the {@code pet} for display to the user.
+     * 
      * @param pet The pet to format.
      *
      * @return The formatted string representation of the pet.
@@ -59,7 +60,10 @@ public class Messages {
         final StringBuilder builder = new StringBuilder();
         builder.append(pet.getName()).append("; Species: ").append(pet.getSpecies())
                 .append("; Breed: ").append(pet.getBreed())
-                .append("; Notes: ").append(pet.getNote());
+                .append("; Notes: ").append(pet.getNote())
+                .append("; Picture: ")
+                .append(pet.getPhotoPath().toString().equals(PLACEHOLDER_IMAGE_PATH) ? "No picture provided"
+                        : pet.getPhotoPath());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,7 +19,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The client index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d clients listed!";
-    public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_FIELDS =
+        "Multiple values specified for the following single-valued field(s): ";
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -51,7 +52,7 @@ public class Messages {
 
     /**
      * Formats the {@code pet} for display to the user.
-     * 
+     *
      * @param pet The pet to format.
      *
      * @return The formatted string representation of the pet.

--- a/src/main/java/seedu/address/logic/commands/AddPetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPetCommand.java
@@ -31,14 +31,14 @@ public class AddPetCommand extends Command {
             + "[" + PREFIX_SPECIES + "SPECIES] "
             + "[" + PREFIX_BREED + "BREED] "
             + "[" + PREFIX_NOTE + "NOTES] "
-            + "[" + PREFIX_PHOTO + "PHOTO PATH] "
+            + "[" + PREFIX_PHOTO + "PICTURE] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Doggy "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_SPECIES + "Dog "
             + PREFIX_BREED + "Labrador "
             + PREFIX_NOTE + "hyper and requires extra care "
-            + PREFIX_PHOTO + "C:\\Users\\DummyUser\\Photos\\doggy.png";
+            + PREFIX_PHOTO + "doggy.png";
 
     public static final String MESSAGE_SUCCESS = "New pet added: %1$s";
     public static final String MESSAGE_NONEXISTENT_PERSON = "There is no client with this phone number";

--- a/src/main/java/seedu/address/logic/commands/EditPetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPetCommand.java
@@ -40,13 +40,13 @@ public class EditPetCommand extends Command {
             + "[" + PREFIX_SPECIES + "SPECIES] "
             + "[" + PREFIX_BREED + "BREED] "
             + "[" + PREFIX_NOTE + "NOTE] "
-            + "[" + PREFIX_PHOTO + "PHOTO PATH] "
+            + "[" + PREFIX_PHOTO + "PICTURE] "
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Meowy "
             + PREFIX_SPECIES + "cat "
             + PREFIX_BREED + "persian "
             + PREFIX_NOTE + "Good kitty "
-            + PREFIX_PHOTO + "C:\\Users\\DummyUser\\Photos\\meowy.png";
+            + PREFIX_PHOTO + "doggy.png";
 
     public static final String MESSAGE_EDIT_PET_SUCCESS = "Edited Pet: %1$s";
     public static final String MESSAGE_NO_INDEX_PASSED = "No POSITION was detected.";

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,7 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_SPECIES = new Prefix("s/");
     public static final Prefix PREFIX_BREED = new Prefix("b/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
-    public static final Prefix PREFIX_PHOTO = new Prefix("ph/");
+    public static final Prefix PREFIX_PHOTO = new Prefix("pic/");
 
     /* Default file paths */
     public static final String PLACEHOLDER_IMAGE_PATH = "/images/placeholder-pet-logo.png";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PLACEHOLDER_IMAGE_PATH;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -184,6 +185,9 @@ public class ParserUtil {
     public static PhotoPath parsePhotoPath(String path) throws ParseException {
         requireNonNull(path);
         String normalized = path.trim();
+        if (normalized.isEmpty()) {
+            return new PhotoPath(PLACEHOLDER_IMAGE_PATH);
+        }
         // Strip surrounding quotes (double or single)
         if ((normalized.startsWith("\"") && normalized.endsWith("\""))
                 || (normalized.startsWith("'") && normalized.endsWith("'"))) {

--- a/src/main/java/seedu/address/model/person/PhotoPath.java
+++ b/src/main/java/seedu/address/model/person/PhotoPath.java
@@ -16,8 +16,11 @@ import java.nio.file.Paths;
  */
 public class PhotoPath {
 
+    private static final Path DATA_PHOTOS_DIR = Paths.get("data", "photos");
+
     public static final String MESSAGE_CONSTRAINTS = "Photo path must be a valid file path "
             + "to an existing image file and cannot be empty. "
+            + "Relative paths are resolved from data/photos/. "
             + "Accepted file extensions: .jpg, .jpeg, .jfif, .png, .gif, .bmp";
 
     public final String value;
@@ -62,7 +65,10 @@ public class PhotoPath {
         // Then, try as a filesystem path using java.nio.file.Path
         try {
             Path path = Paths.get(test);
-            return Files.exists(path);
+            if (!path.isAbsolute()) {
+                path = DATA_PHOTOS_DIR.resolve(path).normalize();
+            }
+            return Files.exists(path) && Files.isRegularFile(path);
         } catch (InvalidPathException e) {
             return false;
         }

--- a/src/main/java/seedu/address/model/person/PhotoPath.java
+++ b/src/main/java/seedu/address/model/person/PhotoPath.java
@@ -16,12 +16,12 @@ import java.nio.file.Paths;
  */
 public class PhotoPath {
 
-    private static final Path DATA_PHOTOS_DIR = Paths.get("data", "photos");
-
     public static final String MESSAGE_CONSTRAINTS = "Photo path must be a valid file path "
             + "to an existing image file and cannot be empty. "
             + "Relative paths are resolved from data/photos/. "
             + "Accepted file extensions: .jpg, .jpeg, .jfif, .png, .gif, .bmp";
+
+    private static final Path DATA_PHOTOS_DIR = Paths.get("data", "photos");
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/PhotoPath.java
+++ b/src/main/java/seedu/address/model/person/PhotoPath.java
@@ -16,9 +16,9 @@ import java.nio.file.Paths;
  */
 public class PhotoPath {
 
-    public static final String MESSAGE_CONSTRAINTS = "Photo path must be a valid file path "
-            + "to an existing image file and cannot be empty. "
-            + "Relative paths are resolved from data/photos/. "
+    public static final String MESSAGE_CONSTRAINTS = "Photo must be a valid file path "
+            + "to an existing image file stored within data/photos/ and cannot be empty "
+            + "(Example: doggy.png). "
             + "Accepted file extensions: .jpg, .jpeg, .jfif, .png, .gif, .bmp";
 
     private static final Path DATA_PHOTOS_DIR = Paths.get("data", "photos");
@@ -65,8 +65,9 @@ public class PhotoPath {
         // Then, try as a filesystem path using java.nio.file.Path
         try {
             Path path = Paths.get(test);
-            if (!path.isAbsolute()) {
-                path = DATA_PHOTOS_DIR.resolve(path).normalize();
+            path = DATA_PHOTOS_DIR.resolve(path).normalize();
+            if (!path.startsWith(DATA_PHOTOS_DIR)) {
+                return false;
             }
             return Files.exists(path) && Files.isRegularFile(path);
         } catch (InvalidPathException e) {

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -72,6 +73,11 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
         requireNonNull(addressBook);
         requireNonNull(filePath);
+
+        Path dataDir = filePath.getParent();
+        if (dataDir != null) {
+            Files.createDirectories(dataDir.resolve("photos"));
+        }
 
         FileUtil.createIfMissing(filePath);
         JsonUtil.saveJsonFile(new JsonSerializableAddressBook(addressBook), filePath);

--- a/src/test/java/seedu/address/commons/util/AppUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/AppUtilTest.java
@@ -7,6 +7,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,6 +46,30 @@ public class AppUtilTest {
     public void loadImage_invalidFilePathImage_loadsFallbackImage() {
         String invalidFilePath = System.getProperty("user.dir") + "/src/main/resources/images/non_existing_image.png";
         assertNotNull(AppUtil.loadImage(invalidFilePath));
+    }
+
+    @Test
+    public void loadImage_relativePathInDataPhotos_loadsImageSuccessfully() throws IOException {
+        Path dataPhotos = Paths.get("data", "photos");
+        Files.createDirectories(dataPhotos);
+        Path tempImage = Files.createTempFile(dataPhotos, "pet-", ".png");
+
+        try (InputStream input = AppUtil.class.getResourceAsStream("/images/placeholder-pet-logo.png")) {
+            Files.copy(input, tempImage, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        assertNotNull(AppUtil.loadImage(tempImage.getFileName().toString()));
+        Files.deleteIfExists(tempImage);
+    }
+
+    @Test
+    public void loadImage_directoryPath_loadsFallbackImage(@TempDir File tempDir) {
+        assertNotNull(AppUtil.loadImage(tempDir.getAbsolutePath()));
+    }
+
+    @Test
+    public void loadImage_invalidPathString_loadsFallbackImage() {
+        assertNotNull(AppUtil.loadImage("invalid\0path.png"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/MessagesTest.java
+++ b/src/test/java/seedu/address/logic/MessagesTest.java
@@ -1,0 +1,94 @@
+package seedu.address.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PLACEHOLDER_IMAGE_PATH;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Breed;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Pet;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.PhotoPath;
+import seedu.address.model.person.Species;
+
+public class MessagesTest {
+
+    @Test
+    public void getErrorMessageForDuplicatePrefixes_multiplePrefixes_success() {
+        String message = Messages.getErrorMessageForDuplicatePrefixes(CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_PHONE);
+        assertTrue(message.startsWith(Messages.MESSAGE_DUPLICATE_FIELDS));
+        assertTrue(message.contains(CliSyntax.PREFIX_NAME.toString()));
+        assertTrue(message.contains(CliSyntax.PREFIX_PHONE.toString()));
+    }
+
+    @Test
+    public void getErrorMessageForDuplicatePrefixes_duplicateInputs_deduplicatesInMessage() {
+        String message = Messages.getErrorMessageForDuplicatePrefixes(CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_NAME);
+        String expected = Messages.MESSAGE_DUPLICATE_FIELDS + CliSyntax.PREFIX_NAME;
+        assertEquals(expected, message);
+    }
+
+    @Test
+    public void getErrorMessageForDuplicatePrefixes_customPrefix_success() {
+        Prefix customPrefix = new Prefix("x/");
+        String expected = Messages.MESSAGE_DUPLICATE_FIELDS + customPrefix;
+        assertEquals(expected, Messages.getErrorMessageForDuplicatePrefixes(customPrefix));
+    }
+
+    @Test
+    public void format_personWithTags_success() {
+        Person person = new Person(new Name("Amy"), new Phone("9123"), new Email("amy@example.com"),
+                new Address("Jurong"), new HashSet<>());
+        person = new seedu.address.testutil.PersonBuilder(person).withTags("vip").build();
+
+        String formatted = Messages.format(person);
+        assertTrue(formatted.contains("Amy"));
+        assertTrue(formatted.contains("Phone: 9123"));
+        assertTrue(formatted.contains("Email: amy@example.com"));
+        assertTrue(formatted.contains("Address: Jurong"));
+        assertTrue(formatted.contains("[vip]"));
+    }
+
+    @Test
+    public void format_personWithoutTags_hasTagsLabelOnly() {
+        Person person = new Person(new Name("Bob"), new Phone("9988"), new Email("bob@example.com"),
+                new Address("Road"), new HashSet<>());
+        String expected = "Bob; Phone: 9988; Email: bob@example.com; Address: Road; Tags: ";
+        assertEquals(expected, Messages.format(person));
+    }
+
+    @Test
+    public void format_petWithPlaceholderPhoto_showsNoPictureProvided() {
+        Pet pet = new Pet(new Name("Snoopy"), new Species("Dog"), new Breed("Beagle"), new Note("Friendly"),
+                new PhotoPath(PLACEHOLDER_IMAGE_PATH));
+        String formatted = Messages.format(pet);
+        assertTrue(formatted.contains("Snoopy"));
+        assertTrue(formatted.contains("Species: Dog"));
+        assertTrue(formatted.contains("Breed: Beagle"));
+        assertTrue(formatted.contains("Notes: Friendly"));
+        assertTrue(formatted.contains("Picture: No picture provided"));
+    }
+
+    @Test
+    public void format_petWithNonPlaceholderPhoto_showsPath() {
+        Pet pet = new Pet(new Name("Milo"), new Species("Cat"), new Breed("Siamese"), new Note("Cute"),
+                new PhotoPath("/images/clock.png"));
+        String formatted = Messages.format(pet);
+        assertTrue(formatted.contains("Picture: /images/clock.png"));
+        assertFalse(formatted.contains("No picture provided"));
+        assertNotEquals(Messages.format(new Pet(new Name("Milo"), new Species("Cat"), new Breed("Siamese"),
+                new Note("Cute"), new PhotoPath(PLACEHOLDER_IMAGE_PATH))), formatted);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PLACEHOLDER_IMAGE_PATH;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -227,5 +229,29 @@ public class ParserUtilTest {
         String singleQuotedPath = "'" + VALID_PHOTO_PATH + "'";
         PhotoPath expectedPhotoPath = new PhotoPath(VALID_PHOTO_PATH);
         assertEquals(expectedPhotoPath, ParserUtil.parsePhotoPath(singleQuotedPath));
+    }
+
+    @Test
+    public void parsePhotoPath_emptyValue_returnsPlaceholderPath() throws Exception {
+        PhotoPath expectedPhotoPath = new PhotoPath(PLACEHOLDER_IMAGE_PATH);
+        assertEquals(expectedPhotoPath, ParserUtil.parsePhotoPath("   "));
+    }
+
+    @Test
+    public void parsePhotoPath_windowsBackslashes_normalizesToForwardSlashes() throws Exception {
+        String windowsPath = "\\images\\clock.png";
+        PhotoPath expectedPhotoPath = new PhotoPath("/images/clock.png");
+        assertEquals(expectedPhotoPath, ParserUtil.parsePhotoPath(windowsPath));
+    }
+
+    @Test
+    public void parsePhotoPath_unmatchedQuotes_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhotoPath("\"/images/clock.png"));
+    }
+
+    @Test
+    public void multipleWords() {
+        assertTrue(ParserUtil.multipleWords("1 two"));
+        assertFalse(ParserUtil.multipleWords("single"));
     }
 }

--- a/src/test/java/seedu/address/model/person/PhotoPathTest.java
+++ b/src/test/java/seedu/address/model/person/PhotoPathTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -99,5 +103,51 @@ public class PhotoPathTest {
     public void isValidPhotoPath_invalidPathCharacters_returnsFalse() {
         // Test to trigger InvalidPathException
         assertFalse(PhotoPath.isValidPhotoPath("invalid\0path.png"));
+    }
+
+    @Test
+    public void isValidPhotoPath_relativePathInDataPhotos_returnsTrue() throws IOException {
+        Path photosDir = Paths.get("data", "photos");
+        Files.createDirectories(photosDir);
+        Path tempImage = Files.createTempFile(photosDir, "photo-path-test-", ".png");
+
+        try {
+            assertTrue(PhotoPath.isValidPhotoPath(tempImage.getFileName().toString()));
+        } finally {
+            Files.deleteIfExists(tempImage);
+        }
+    }
+
+    @Test
+    public void isValidPhotoPath_absoluteRegularFileWithImageExtension_returnsFalse() throws IOException {
+        Path imagePath = Paths.get("data", "photos", "absolute-valid.jpg").toAbsolutePath();
+        Files.createDirectories(imagePath.getParent());
+        Files.createFile(imagePath);
+        try {
+            assertFalse(PhotoPath.isValidPhotoPath(imagePath.toString()));
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    @Test
+    public void isValidPhotoPath_absolutePathToDirectoryWithImageExtension_returnsFalse(@TempDir File tempDir)
+            throws IOException {
+        Path dirPath = tempDir.toPath().resolve("folder.png");
+        Files.createDirectory(dirPath);
+        assertFalse(PhotoPath.isValidPhotoPath(dirPath.toString()));
+    }
+
+    @Test
+    public void isValidPhotoPath_relativePathOutsideDataPhotosWhenFileExists_returnsFalse() throws IOException {
+        Path tempImage = Paths.get("data", "photos").resolve("../outside.png").normalize();
+        Files.createDirectories(tempImage.getParent());
+        Files.createFile(tempImage);
+
+        try {
+            assertFalse(PhotoPath.isValidPhotoPath("../outside.png"));
+        } finally {
+            Files.deleteIfExists(tempImage);
+        }
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.HOON;
@@ -9,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.IDA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -106,5 +108,36 @@ public class JsonAddressBookStorageTest {
     @Test
     public void saveAddressBook_nullFilePath_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> saveAddressBook(new AddressBook(), null));
+    }
+
+    @Test
+    public void saveAddressBook_createsDataPhotosSubdirectory() throws Exception {
+        Path nestedFilePath = testFolder.resolve(Paths.get("nested", "book.json"));
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(nestedFilePath);
+
+        storage.saveAddressBook(getTypicalAddressBook(), nestedFilePath);
+
+        assertTrue(Files.exists(nestedFilePath.getParent().resolve("photos")));
+        assertTrue(Files.isDirectory(nestedFilePath.getParent().resolve("photos")));
+    }
+
+    @Test
+    public void readAddressBook_nullPath_throwsNullPointerException() {
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(testFolder.resolve("book.json"));
+        assertThrows(NullPointerException.class, () -> storage.readAddressBook((Path) null));
+    }
+
+    @Test
+    public void saveAddressBook_nullPath_throwsNullPointerException() {
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(testFolder.resolve("book.json"));
+        assertThrows(NullPointerException.class, ()
+            -> storage.saveAddressBook(getTypicalAddressBook(), (Path) null));
+    }
+
+    @Test
+    public void getAddressBookFilePath_returnsConstructorPath() {
+        Path filePath = testFolder.resolve("book.json");
+        JsonAddressBookStorage storage = new JsonAddressBookStorage(filePath);
+        assertEquals(filePath, storage.getAddressBookFilePath());
     }
 }


### PR DESCRIPTION
Changes made:
* Modify photopath tag from `ph/` to `pic/` for disambiguation with phone tag `p/`
* Photopath now takes in a relative filepath from the `data/photos/` subdirectory
  * Resolves #219 
  * Resolves #187
  * Resolves #185
* Leaving the `pic/` tag empty removes any photo
  * Resolves #193 
* Corresponding documentation changes

Other issues resolved:
* Resolves #196 
* Resolves #229 