### PR TITLE
UG Edits

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -430,12 +430,12 @@ A **Precondition** is that the system is displaying the list of clients and pets
     * 1a1. System notifies user.
      Use case ends.
 
-* 2a. The given parameters are invalid.
+* 2a. The given index is invalid.
 
     * 2a1. System shows an error message.
     * 2a2. User makes new request to delete a client.
 
-      Steps 2a1-2a2 are repeated until the parameters are valid.
+      Steps 2a1-2a2 are repeated until the index is valid.
 
       Use case resumes at step 3.
 
@@ -457,11 +457,11 @@ A **Precondition** is that the system is displaying the list of clients and pets
     * 1a1. System notifies user.
      Use case ends.
 
-* 2a. The given parameters are invalid.
+* 2a. The given index is invalid.
 
     * 2a1. System shows an error message.
     * 2a2. User makes new request to delete a pet from a client.
-      Steps 2a1-2a2 are repeated until the parameters are valid.
+      Steps 2a1-2a2 are repeated until the index is valid.
 
       Use case resumes at step 3.
 
@@ -482,11 +482,11 @@ A **Precondition** is that the system is displaying the list of clients and pets
     * 1a1. System notifies user.
      Use case ends.
 
-* 2a. The given parameters are invalid.
+* 2a. The given index is invalid.
 
     * 2a1. System shows an error message.
     * 2a2. User makes new request to edit a client.
-      Steps 2a1-2a2 are repeated until the parameters are valid.
+      Steps 2a1-2a2 are repeated until the index is valid.
 
       Use case resumes at step 3.
 
@@ -507,11 +507,11 @@ A **Precondition** is that the system is displaying the list of clients and pets
     * 1a1. System notifies user.
      Use case ends.
 
-* 2a. The given parameters are invalid.
+* 2a. The given index is invalid.
 
     * 2a1. System shows an error message.
     * 2a2. User makes new request to edit a pet.
-      Steps 2a1-2a2 are repeated until the parameters are valid.
+      Steps 2a1-2a2 are repeated until the index is valid.
 
       Use case resumes at step 3.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -34,10 +34,10 @@ Refer to the guide [_Setting up and getting started_](SettingUp.md).
 
 The ***Architecture Diagram*** shows the high-level design of the app.
 It is a Model-View-Controller design, where
-* The user interacts with the [**`UI`**](#ui-component)...
-* Requested changes are passed through the [**`Logic`**](#logic-component) interface...
-* These changes are reflected in the [**`Model`**](#model-component) and [**`Storage`**](#storage-component)...
-* And the [**`UI`**](#ui-component) listens for and displays changes accordingly.
+* The user interacts with the [**`UI`**](#ui-component), which accepts text commands and displays results.
+* Requested changes are passed through the [**`Logic`**](#logic-component) interface, which parses and executes commands.
+* These changes are reflected in the [**`Model`**](#model-component) (in-memory state) and [**`Storage`**](#storage-component) (persisted JSON file).
+* The [**`UI`**](#ui-component) listens for changes to `Model` data and updates the display accordingly.
 
 ### Sequence of program execution
 
@@ -133,6 +133,7 @@ The `Model` component,
 * stores the address book data i.e., all `Person` (client) objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * stores a `UserPrefs` object that represents the user's preferences. This is exposed to the outside as a `ReadOnlyUserPrefs` objects.
+* stores all `Pet` objects embedded within `Person` objects. Each `Person` holds a list of `Pet` objects, each with a `Name`, `Species`, `Breed`, `Note`, and optionally a `PhotoPath`.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components).
 
 <puml src="diagrams/ModelSequenceDiagram.puml" alt="Interactions Inside the Model Component for the `deleteClient 1` Command" />
@@ -152,6 +153,7 @@ How the `Model` component works:
 The `Storage` component,
 * can save both address book data and user preference data in JSON format, and read them back into corresponding objects.
 * inherits from both `AddressBookStorage` and `UserPrefsStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
+* serializes `Pet` objects via `JsonAdaptedPet`, nested within `JsonAdaptedPerson`, allowing the full client-pet hierarchy to be saved and restored from a single JSON file (`data/addressbook.json`).
 * depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
 
 --------------------------------------------------------------------------------------------------------------------
@@ -175,6 +177,56 @@ Each `Person` (client) contains a `List<Pet>` representing their owned pets. Thi
 * **Pet indexing**: Pets are indexed **globally** across all clients in the displayed list. For example, if Client 1 has pets A and B, and Client 2 has pet C, their indexes would be 1, 2, and 3 respectively. This sequential indexing is used by `editPet` and `deletePet` commands.
 
 * **Pet-Client linking**: When adding a pet via `addPet`, the pet is linked to a client using the client's **phone number** (not the client's index). This ensures the link remains stable even when the client list is filtered or reordered.
+
+The sequence diagram below illustrates the interactions within the `Logic` and `Model` components when executing `addPet n/Max p/87438807 s/Dog`:
+
+<puml src="diagrams/AddPetSequenceDiagram.puml" alt="Interactions for the `addPet n/Max p/87438807 s/Dog` Command" />
+
+Unlike `deleteClient` (which uses a list index), `addPet` uses a **phone number lookup**. The command first checks that a client with the given phone exists (`Model#hasPhone()`), then checks that the pet name is not a duplicate for that owner (`Model#hasPet()`), before finally calling `Model#addPet()`.
+
+### \[Actual\] Find feature
+
+The `find` command filters the displayed list of clients (and their pets) based on one or more keywords.
+
+**How `FindPredicate` works:**
+
+`FindPredicate` (in `model/person/FindPredicate.java`) implements `Predicate<Person>`. It requires **all** keywords to match (AND logic), but each keyword can match **any** field — a keyword is satisfied if it appears in:
+* the client's name, phone number, email, or address
+* any of the client's tags
+* any of the client's pets' name, species, breed, or grooming notes
+
+Matching is **case-insensitive** and **partial-word** (e.g., `find alex` matches a client named "Alexander").
+
+**Filtering is applied at the `Person` level:** if a `Person` (client) satisfies all keywords, the entire entry — including all their pets — is shown. This means a search for `find alex dog` shows any client whose fields (or whose pets' fields) together contain both "alex" and "dog".
+
+**Design consideration:**
+
+| Alternative | Pros | Cons |
+|---|---|---|
+| Current: filter at `Person` level | Simple; only one `ObservableList<Person>` needed | Shows all of a client's pets even if only one pet matched |
+| Filter at `(Person, Pet)` pair level | More precise — only matching pets shown | Requires structural changes to `Model` and `UI` |
+
+The pair-level approach is listed as a planned enhancement (see Appendix: Planned Enhancements).
+
+### \[Actual\] Pet photo feature
+
+Pets can optionally have a photo attached, stored as a `PhotoPath` value.
+
+**How `PhotoPath` validation works:**
+
+When a `pic/` argument is provided to `addPet` or `editPet`, the `PhotoPath` class validates it:
+1. The file extension must be one of: `.jpg`, `.jpeg`, `.jfif`, `.png`, `.gif`, `.bmp`.
+2. It first attempts to load the path as a **classpath resource** (used for bundled sample images).
+3. If that fails, it resolves the filename against the `data/photos/` directory and checks the file exists on disk.
+4. Path traversal is blocked — any path that escapes `data/photos/` after normalisation is rejected.
+
+**Storage:** Only the filename string is saved in JSON. The actual image file must be present in `data/photos/` at runtime.
+
+**Fallback:** If a pet has no `PhotoPath`, or if the referenced file is missing at startup, the UI displays a placeholder paw icon instead.
+
+**Design consideration:**
+
+Embedding image data (e.g., Base64) in the JSON would eliminate the need for users to manually manage `data/photos/`, but would significantly increase file size and make the JSON unreadable. Storing only the path keeps the data file lightweight and human-editable.
 
 ### \[Proposed\] Undo/redo feature
 
@@ -515,21 +567,35 @@ A **Precondition** is that the system is displaying the list of clients and pets
 
       Use case resumes at step 3.
 
-**Use case 7: Search for pet or client**
+**Use case 7: Search for clients and pets by keywords**
 
 **MSS**
 
-1.  User requests to filter the list.
-2.  System displays a filtered list.
-3.  User looks for their pet or client.
+1.  User provides one or more keywords to the `find` command.
+2.  System displays all clients where **all** keywords match at least one of: the client's name, phone, email, address, tags, or any of their pets' name, species, breed, or grooming notes.
+3.  User locates the desired client or pet in the filtered list.
 
     Use case ends.
 
 **Extensions**
 
-* 2a. The user wants to use a different filter.
+* 2a. No client matches all the keywords.
 
-     Use case resumes at step 1.
+    * 2a1. System displays an empty list with a "0 clients listed" message.
+
+      Use case ends.
+
+* 2b. User wants a broader search.
+
+    * 2b1. User reruns `find` with fewer keywords.
+
+      Use case resumes at step 2.
+
+* 2c. User wants to restore the full list after searching.
+
+    * 2c1. User runs `list`.
+
+      Use case ends.
 
 **Use case 8: Delete all records**
 
@@ -702,20 +768,147 @@ testers are expected to do more *exploratory* testing.
    1. Test case: `find alex`, given client `Alex Yeoh` exists and nobody else matches `alex`<br>
       Expected: Only client `Alex Yeoh` is displayed.
 
+   1. Test case: `find alex dog`, given `Alex Yeoh` owns a pet with species `Dog`<br>
+      Expected: `Alex Yeoh` and all their pets are displayed, because both keywords are satisfied across the client and pet fields.
+
+   1. Test case: `find xyzzy`<br>
+      Expected: No clients displayed. Status message shows `0 clients listed`.
+
    1. Other correct commands to try: Partial matches across all keywords, matching across owner and pet<br>
-      Expected: If a client or pet matches the keywords, the client and all their pets are displayed.
+      Expected: If a client or pet matches all keywords, the client and all their pets are displayed.
+
+### Listing all clients and pets
+
+1. Restoring the full list after a `find` command.
+
+   1. Prerequisites: Run `find alex` so the list is filtered.
+
+   1. Test case: `list`<br>
+      Expected: All clients and their pets are shown. Status message confirms the full list is displayed.
+
+### Adding grooming notes
+
+1. Adding and clearing a grooming note on a pet.
+
+   1. Prerequisites: At least one client exists. Use `list` to confirm.
+
+   1. Test case: `addPet n/Max p/87438807 s/Dog b/Beagle nt/Sensitive to loud noises` where the client with phone `87438807` exists<br>
+      Expected: Pet is added with the grooming note visible in the UI.
+
+   1. Test case: `editPet 1 nt/`<br>
+      Expected: Grooming note is cleared for the pet at index 1. Pet entry updates immediately.
+
+   1. Test case: `find Sensitive` after adding a pet with `nt/Sensitive to loud noises`<br>
+      Expected: The client owning that pet is shown, because grooming notes are included in search.
+
+### Adding and editing a pet photo
+
+1. Adding a photo to a pet.
+
+   1. Prerequisites: Place an image file (e.g., `max.png`) inside the `data/photos/` directory. Use `list` to confirm at least one client exists.
+
+   1. Test case: `addPet n/Max p/87438807 s/Dog b/Beagle pic/max.png`<br>
+      Expected: Pet is added with the photo displayed in the UI.
+
+   1. Test case: `editPet 1 pic/max.png`<br>
+      Expected: Photo is updated for the pet at index 1.
+
+   1. Test case: `addPet n/Ghost p/87438807 s/Cat pic/nonexistent.png`<br>
+      Expected: No pet added. Error message shown indicating the photo file was not found.
+
+   1. Test case: `addPet n/Ghost p/87438807 s/Cat pic/../../secret.png`<br>
+      Expected: No pet added. Error message shown (path traversal outside `data/photos/` is blocked).
+
+### Using tags
+
+1. Adding and clearing tags on a client.
+
+   1. Test case: `addClient n/Alice p/91234567 e/alice@example.com a/123 Street t/VIP`<br>
+      Expected: Client added with a `VIP` tag shown.
+
+   1. Test case: `editClient 1 t/Regular t/Discount`<br>
+      Expected: Tags on client at index 1 are replaced with `Regular` and `Discount`.
+
+   1. Test case: `editClient 1 t/`<br>
+      Expected: All tags removed from client at index 1.
+
+   1. Test case: `find VIP` after adding a client tagged `VIP`<br>
+      Expected: That client is shown, because tags are included in search.
+
+### Clearing all records
+
+1. Clearing the address book.
+
+   1. Prerequisites: At least one client exists.
+
+   1. Test case: `clear`<br>
+      Expected: All clients and pets are deleted. An empty list is shown.
+
+   1. Test case: `clear` when the list is already empty<br>
+      Expected: The list remains empty. No error shown.
+
+### Help and exit
+
+1. Opening help and exiting.
+
+   1. Test case: `help`<br>
+      Expected: A help window opens showing command usage information.
+
+   1. Test case: `exit`<br>
+      Expected: The application closes cleanly.
 
 ## **Appendix: Effort**
 
-Our project extended AB3 by including pets as an additional attribute for person.
-We changed the layout of the UI to make it more appealing.
-Extending the existing commands to include a new entity should have saved a significant amount of effort, but adapting the tests turned out to be very tedious.
-An unexpected challenge was addressing pets with indexes, since we only had an ObservablePersonList to work with.
+**Difficulty level:** Moderate to high, relative to AB3.
+
+AB3 manages a single entity (`Person`). Hairy Pawter manages two entities (`Person` and `Pet`) in a **one-to-many** relationship, requiring changes across every component of the application.
+
+**Challenges encountered and effort required:**
+
+* **Global pet indexing.** AB3 uses a simple list index for persons. Hairy Pawter needs a global sequential index across all pets (e.g., if Client 1 has pets A and B, and Client 2 has pet C, their indexes are 1, 2, 3). Since only `ObservableList<Person>` is exposed, computing these indexes required iterating over all persons and their embedded pet lists, which was not trivial to integrate cleanly with commands and the UI.
+
+* **Immutable `Person` with embedded pets.** `Person` objects are immutable. Any pet modification — add, edit, or delete — requires creating a new `Person` with the updated pet list and replacing it in the `UniquePersonList`. This pattern had to be implemented consistently across `AddPetCommand`, `EditPetCommand`, and `DeletePetCommand`.
+
+* **Adapting existing tests.** Every existing AB3 test assumed `Person` had no pets. Updating them — and writing new tests for pet-related commands — accounted for a large share of total effort, more than writing the production code itself.
+
+* **Phone-based pet linking.** The decision to link pets to clients by phone number (not index) was necessary for stability under filtering, but it required `AddPetCommand` to perform a lookup that is structurally different from all other commands, and this difference had to be clearly communicated to contributors.
+
+* **Photo feature.** Implementing `PhotoPath` validation — covering file extensions, path traversal prevention, classpath resources, and graceful fallback to a placeholder icon — was more involved than a typical optional field.
+
+* **Storage for nested entities.** Adding `JsonAdaptedPet` nested within `JsonAdaptedPerson` while maintaining JSON compatibility required careful handling of optional fields (species, breed, notes, photo path).
+
+**Appendix: Effort:**
+
+* **UI restructuring.** The UI restructuring (showing `PetPersonCard` with a `PersonCard` and one or more `PetCard` objects side by side) was an additional non-trivial effort.
+
+**Achievements:**
+
+* Fully functional two-entity CRUD system with client-pet linking.
+* Unified `find` command searching across all client and pet fields.
+* Pet photo support with runtime validation and graceful fallback.
+* Grooming notes integrated into search.
+* Custom UI layout tailored to a pet grooming workflow.
 
 ## **Appendix: Planned enhancements**
 
 Team size: 5
 
-1. **Make find function more specific:** The current find function returns pets that are not related to the search.
-The find function can be made more specific by saving an additional predicate in the model that takes in a pair of pet and person.
-The methods `getFilteredPersonList()`, `getPerson()` and `getPet()` will use the additional predicate to do another round of filtering.
+1. **Make find function more specific:** The current `find` command returns a client and **all** their pets if any field matches, even if only one pet was the actual match. The fix is to introduce a pair-predicate in the `Model` that filters at the `(Person, Pet)` level. `getFilteredPersonList()` would expose only the clients that matched, and the UI would render only the matched pets for each such client. This requires changes to `ModelManager`, the filtered list logic, and `PetPersonListPanel`.
+
+2. **Allow `pic/` to clear a photo:** Currently there is no way to remove a photo once it has been set on a pet — `editPet` requires `pic/` to point to a valid file. The fix is to treat `pic/` (with no argument) as a sentinel that clears the photo, consistent with how `t/` clears tags in `editClient`. This requires a change in `EditPetCommandParser` and `EditPetCommand` to distinguish between an absent `pic/` prefix and a present-but-empty one.
+
+3. **Improve duplicate-pet error message:** When `addPet` or `editPet` is rejected because a pet with the same name already exists for that owner, the error message says only "This pet already exists." The fix is to include the duplicate's name and owner in the message, e.g. `A pet named 'Max' already exists for client 87438807.`, so users can quickly identify the conflict.
+
+4. **Enforce minimum phone number length:** Currently any non-empty string of digits is accepted as a phone number by `Phone`, including single-digit values. The fix is to enforce a minimum of 3 digits in `Phone#isValidPhone()`. Sample input that should be rejected: `p/1`, `p/12`.
+
+5. **Show pet count in status bar:** The current status bar shows only the data file path. Adding a live count such as `5 clients · 12 pets` would give users at-a-glance information about the size of their database without needing to scroll. This requires a listener on the `ObservableList<Person>` in `StatusBarFooter` and a utility to sum pet counts across all persons.
+
+6. **Improve phone-conflict error message in `editClient`:** When a client's phone is changed to one already used by another client, the error says "This person already exists in the address book." The fix is to make the message more specific: `Phone number 87438807 is already in use by another client.`
+
+7. **Prevent accidental `clear` with a confirmation step:** The `clear` command permanently deletes all clients and pets with no warning. The fix is to require users to confirm by typing `clear --confirm`, or to display a confirmation prompt in the result display that must be acknowledged before the deletion proceeds.
+
+8. **Support prefix-based `find` for specific fields:** Currently `find dog` matches "dog" anywhere — names, notes, species, etc. — which can return unexpected results. The fix is to allow optional prefixes such as `find s/Dog b/Beagle` to restrict the search to specific fields, while keeping bare keyword search as a fallback for the general case.
+
+9. **Make address and email optional in `addClient`:** Both `a/` and `e/` are currently required parameters, which forces users to enter placeholder values when a client's email or address is unknown. The fix is to make these fields optional, defaulting to empty strings when omitted, matching how `Species`, `Breed`, `Note`, and `PhotoPath` are optional in `addPet`.
+
+10. **Improve `find` result message to include pet count:** The current result message after `find` says `N clients listed`, but gives no information about how many pets were matched. The fix is to update the message to `N clients listed (M pets)` by counting pets in the filtered list, providing more feedback without requiring the user to count manually.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,84 +6,131 @@
 
 # Hairy Pawter User Guide
 
-Hairy Pawter is a desktop app created to help pet groomers reach their clients.
-It works independently of other apps, and can help groomers handle both walk-in clients and clients who arrive for appointments.
+Hairy Pawter is a desktop app for **pet groomers** to manage client and pet records.
 
-Use Hairy Pawter to quickly jot down contact details of clients and their pets when they arrive,
-so that after grooming a pet, you can quickly find the details of the owner and contact them.
+Use it to:
+- Record the contact details and pets of clients when they walk in
+- Track each pet's species, breed, notes, and photos for easy identification
+- Quickly find a client's contact details after finishing a grooming session
+- Manage both walk-in and appointment clients in one place
 
 <!-- * Table of Contents -->
 <page-nav-print />
 
 --------------------------------------------------------------------------------------------------------------------
 
-## Installation
+## Who is this guide for?
 
-1. [Install](https://se-education.org/guides/tutorials/javaInstallation.html) `Java 17` or higher to your computer.
+This guide is written for **pet groomers** who manage their own client base.
 
-   * `Java 17` is reputable software that Hairy Pawter needs to function.
+**No programming experience is needed.** However, you should be comfortable typing short commands into a text field, as Hairy Pawter is a keyboard-first app.
+
+If you are setting up Hairy Pawter for the first time, start with the [Quick Start](#quick-start) section below.
+
+--------------------------------------------------------------------------------------------------------------------
+
+## Quick Start
+
+### Installation
+
+1. [Install](https://se-education.org/guides/tutorials/javaInstallation.html) `Java 17` or higher on your computer.
+
+   * `Java 17` is the software that Hairy Pawter needs to run.
 <br><br>
 
 1. Download `hairypawter.jar` from the latest release [here](https://github.com/AY2526S2-CS2103T-F14-2/tp/releases).
 
-   * You should be able to see it inside your Downloads folder.
+   * It will appear in your Downloads folder.
 <br><br>
 
-1. Move `hairypawter.jar` to the folder you want to use as the _home folder_ for this app.
+1. Move `hairypawter.jar` to the folder you want to use as the _home folder_ for Hairy Pawter.
 
-   * You can create a folder called Hairypawter and drag `hairypawter.jar` inside it.
+   * You can create a new folder called `HairyPawter` and move the file inside it.
 <br><br>
 
-1. Double-click on `hairypawter.jar` to run it
+1. Double-click `hairypawter.jar` to run Hairy Pawter.
 
 <box type="info" seamless>
 
-**If double-clicking does not run the app:**<br>
+**If double-clicking does not open the app:**
 
-5. Open a command terminal
+Open a command terminal:
+* **Windows:** Search for `Command Prompt` in the taskbar search.
+* **Mac:** Press `Cmd` + `Space` and search for `Terminal`.
+* **Linux:** Try `Ctrl` + `Alt` + `T`.
 
-    * Windows users can use the search bar on the bottom of the screen to search for `Command Prompt` and run it.
+In the terminal, navigate to your home folder using `cd PATH_TO_HOME_FOLDER`.<br>
+e.g. `cd C:\Users\jeff\Desktop\HairyPawter\`
 
-    * Mac users can use spotlight search `Cmd` + `SPACE` to search for `Terminal` and run it.
+Then run: `java -jar hairypawter.jar`
 
-    * Linux users can try `Ctrl` + `Alt` + `T`.
-
-6. In the command terminal, enter the command `cd PATH` where PATH is the location of the _home folder_. (e.g. `cd C:\Users\jeff\Desktop\HairyPawter\`)
-    
-    * You can right click on the _home folder_ and select the option most similar to `Copy as path`, then paste it after `cd `.
-
-
-7. In the command terminal, enter the command `java -jar hairypawter.jar` to start the app.
-
-    * Once the app starts, you can ignore the rest of the activity on the command terminal. Closing it will close the app.
+You can ignore any other output in the terminal while the app is running. Closing the terminal will also close the app.
 
 </box>
 
-<img src="images/Ui.png" class="app-screenshot" alt="Ui">
+### Overview of the interface
+
+<img src="images/Ui.png" class="app-screenshot" alt="Hairy Pawter interface">
+
+When Hairy Pawter opens, you will see four areas:
+
+| Area | Location | Purpose |
+|------|----------|---------|
+| **Client list** | Left panel | Displays all clients and their contact details |
+| **Pet list** | Right panel | Displays the pets belonging to each client |
+| **Result box** | Above the command box | Shows the outcome of your last command |
+| **Command box** | Bottom of the window | Type your commands here and press Enter |
+
+### Try it yourself: a first session
+
+Follow these steps to get started. Type each command into the command box and press Enter.
+
+1. `addClient n/John Tan p/91234567 e/john@email.com`<br>
+   Adds a client named John Tan with phone number 91234567.
+
+2. `addPet n/Biscuit p/91234567 s/Dog b/Golden Retriever nt/Loves belly rubs`<br>
+   Adds a dog named Biscuit under John Tan's account (matched by phone number).
+
+3. `find Biscuit`<br>
+   Filters the list to show only records matching "Biscuit".
+
+4. `list`<br>
+   Returns to the full list of all clients and pets.
+
+5. `deleteClient 1`<br>
+   Deletes the client at position 1 and all their pets.
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Commands
 
-In the app, type a command in the command box (at the bottom) and press Enter to execute it. (e.g. typing **`help`** and pressing Enter will open the help window)<br>
+Type a command into the command box and press Enter to run it. For example, typing `help` and pressing Enter opens the help window.
 
 <box type="info" seamless>
 
-**Reading the command guide:**<br>
+**Reading the command format:**<br>
 
-* Words in `UPPER_CASE` should be replaced with real values.<br>
-  e.g. `client n/NAME` should be used as `client n/John Doe`.
+* Words in `UPPER_CASE` are placeholders — replace them with real values.<br>
+  e.g. `addClient n/NAME` should be typed as `addClient n/John Doe`.
 
 * Items in square brackets are optional.<br>
-  e.g `[t/TAG]` can be ignored.
+  e.g. `[t/TAG]` can be left out entirely.
 
-* Items with `…` can be used multiple times.<br>
-  e.g. `[t/TAG]…` can be used as `t/friend t/family`
+* Items with `…` can be repeated multiple times.<br>
+  e.g. `[t/TAG]…` can be typed as `t/friend t/family`.
 
-* Items can be in any order.<br>
-  e.g. if the command specifies `n/NAME p/PHONE`, `p/PHONE n/NAME` is also acceptable.
+* Parameters can be in any order.<br>
+  e.g. if the format shows `n/NAME p/PHONE`, typing `p/PHONE n/NAME` also works.
 
-* If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
+* **`POSITION`** refers to the number displayed next to a client or pet in the list. It changes whenever you use `find` or `list`, so always check the current number before editing or deleting.
+
+* If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines, as space characters around line-breaks may be dropped.
+</box>
+
+<box type="tip" seamless>
+
+**Tip:** Most commands have a short-form alias for faster typing. See the [Short-form commands](#short-form-commands) section.
+
 </box>
 
 ### Viewing help : `help`
@@ -100,11 +147,12 @@ Format: `help`
 
 ### Adding a client: `addClient`
 
-Registers a new client. The new client will be shown at the top of the list.
+Registers a new client. The new client appears at the top of the list.
 
-<box type="tip" seamless>
+<box type="warning" seamless>
 
-**Important:** Clients cannot have the same phone number.
+**Constraint:** Each client must have a unique phone number. You cannot add two clients with the same phone number.
+
 </box>
 
 Format: `addClient p/PHONE [n/NAME] [e/EMAIL] [a/ADDRESS] [t/TAG]…`
@@ -113,28 +161,40 @@ Examples:
 * `addClient n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `addClient n/Betsy Crowe t/friend e/betsycrowe@example.com a/Crown street p/1234567`
 
-Remarks:
-The new client may not be shown if there is an active `find` condition that it does not satisfy.
-If this happens, use `list` to show all clients.
-
-Optional values will appear as `-`.
+**Expected output:**
+```
+New client added: John Doe; Phone: 98765432; Email: johnd@example.com; Address: John street, block 123, #01-01; Tags:
+```
 
 <box type="info" seamless>
 
-**Using `[t/TAG]...` to your advantage:**<br>
+**Note:** If you have used `find` and the new client does not match your search terms, they will not appear in the current view. Type `list` to see all clients.
 
-* You can use many `[t/TAG]`s to note down additional information about a client.
+Omitted fields will appear as `-`.
 
-* These can be their preferences, or the date they visited for easy searching.
+</box>
+
+<box type="tip" seamless>
+
+**Tip — using `[t/TAG]…` effectively:**
+* Add multiple tags to record extra information, such as a client's grooming preferences or the date of their last visit (e.g. `t/2025-03-15`).
+* Tags are searchable with the `find` command, making it easy to filter by visit date or any other label.
+
 </box>
 
 <br><br>
 
 ### Adding a pet: `addPet`
 
-Registers a new pet of a client. The name of the pet and the **phone number of the client** are needed.
+Registers a new pet under an existing client. The client is identified by their phone number.
 
-Note: Pets can only be added after their owner has been added.
+<box type="warning" seamless>
+
+**Constraints:**
+* The client must already be registered in Hairy Pawter before you can add their pet. Use [`addClient`](#adding-a-client-addclient) first.
+* A client cannot have two pets with the same name.
+
+</box>
 
 Format: `addPet n/NAME p/PHONE [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]`
 
@@ -143,8 +203,16 @@ Examples:
 * `addPet n/Meowy p/123456`
 * `addPet n/Doggy p/81234567 pic/doggy.png`
 
-Remarks:
-Optional values will appear as `Unknown` or `None`.
+**Expected output:**
+```
+New pet added: Snowy; Species: Dog; Breed: Wire Fox Terrier (White); Notes: None; Picture: No picture provided
+```
+
+<box type="info" seamless>
+
+Omitted fields will appear as `Unknown` or `None`.
+
+</box>
 
 <box type="info" seamless>
 
@@ -170,50 +238,73 @@ like leash colour, or allergies and quirks of the pet. Use this flexibly!
 
 ### Listing all clients and pets : `list`
 
-Shows all clients and pets.
+Shows all clients and their pets.
 
 Format: `list`
+
+**Expected output:**
+```
+Listed all clients
+```
 
 <br><br>
 
 ### Editing a client : `editClient`
 
-Edits an existing client.
+Edits the details of an existing client.
 
-* Edits the client at the specified `POSITION`. The `POSITION` refers to the number shown next to the client.
-* Specified values will override old values.
-* Editing tags will clear previous tags.
-* You can remove a client’s tags by typing `t/` without specifying any tags after it.
+* Edits the client at the specified `POSITION`.
+* Only the fields you provide will be updated; all other fields remain unchanged.
+* Editing tags replaces all existing tags. To remove all tags, use `t/` with no value.
 
 Format: `editClient POSITION [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
-* You need to edit at least one of the optional values.
+
+At least one field (`n/`, `p/`, `e/`, `a/`, or `t/`) must be provided.
 
 Examples:
-*  `editClient 1 p/91234567 e/johndoe@example.com` Edits the details of the client in `POSITION` 1.
-*  `editClient 2 n/Betsy Crower t/` Changes the name of the client in `POSITION` 2 to `Betsy Crower` and clears their tags.
+* `editClient 1 p/91234567 e/johndoe@example.com` — updates the phone and email of the client at position 1.
+* `editClient 2 n/Betsy Crower t/` — renames the client at position 2 and removes all their tags.
+
+**Expected output:**
+```
+Edited Client: Betsy Crower; Phone: 1234567; Email: betsycrowe@example.com; Address: Crown street; Tags:
+```
+
+<box type="info" seamless>
+
+**Note:** Changing a client’s phone number does not affect their pets — the pets remain associated with that client under the new phone number.
+
+</box>
 
 <br><br>
 
 ### Editing a pet : `editPet`
 
-Edits an existing pet.
+Edits the details of an existing pet.
 
-* Edits the pet at the specified `POSITION`. The `POSITION` refers to the number shown next to the pet.​
-* Specified values will override old values.
-* You can remove a pet's picture by typing `pic/` without specifying any filename after it.
+* Edits the pet at the specified `POSITION`.
+* Only the fields you provide will be updated; all other fields remain unchanged.
+* To remove a pet's photo, use `pic/` with no value.
+* A pet's owner cannot be changed with `editPet`. To reassign a pet to a different owner, delete the pet with [`deletePet`](#deleting-a-pet-deletepet) and re-add it with [`addPet`](#adding-a-pet-addpet).
 
 Format: `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED]​ [nt/NOTES] [pic/PICTURE]`
-* You need to edit at least one of the optional values.
+
+At least one field must be provided.
 
 Examples:
-*  `editPet 1 s/cat` Edits the species of the pet in `POSITION` 1.
-*  `editPet 2 n/Gunner` Changes the name of the pet in `POSITION` 2 to `Gunner`.
+* `editPet 1 s/Cat` — updates the species of the pet at position 1.
+* `editPet 2 n/Gunner nt/Nervous around strangers` — renames the pet at position 2 and updates their notes.
+
+**Expected output:**
+```
+Edited Pet: Gunner; Species: Unknown; Breed: Unknown; Notes: Nervous around strangers; Picture: No picture provided
+```
 
 <box type="info" seamless>
 
-Click [here](#more-about-picpicture) for more details on how to use the picture `pic/` tag!
+Click [here](#more-about-picpicture) for more details on using the `pic/` tag.
 
-Click [here](#using-ntnotes-to-your-advantage) to see how you could use the notes `nt/` tag to your advantage!
+Click [here](#using-ntnotes-to-your-advantage) to see how to use the `nt/` tag.
 
 </box>
 
@@ -221,20 +312,30 @@ Click [here](#using-ntnotes-to-your-advantage) to see how you could use the note
 
 ### Locating clients and pets by keywords: `find`
 
-Shows pets and clients who match **all** of the given keywords.
-This searches all the records, including client tags and pet notes.
+Filters the list to show only clients and pets that match **all** of the given keywords.
 
-This restriction will remain until `list` is called.
+* The search covers all fields: client name, phone, email, address, tags, and pet name, species, breed, and notes.
+* Matching is partial and case-insensitive (e.g. `Roy` matches `Leroy`).
+* All keywords must match — e.g. `Hans Bo` only shows results where both `Hans` and `Bo` appear somewhere in the record.
+* Keyword order does not matter.
+* This filter stays active until you run `list`.
 
-* The match is partial and case-insensitive. e.g `Roy` will match `Leroy`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-
-Format: `find KEYWORD...`
+Format: `find KEYWORD…`
 
 Examples:
-* `find Yu` returns clients named `yusuf` and `Yuri` with their pets.
-* `find Yu cat` returns clients with their pets, if both `yu` and `cat` appear in either their details or any of their pets' details.
+* `find Yu` — shows clients named `Yusuf` or `Yuri` and their pets.
+* `find Yu cat` — shows records where both `yu` and `cat` appear anywhere across the client's or their pets' details.
 
+**Expected output:**
+```
+2 clients listed!
+```
+
+<box type="info" seamless>
+
+**Note:** The result count shows the number of **clients** matched, not pets.
+
+</box>
 
 <img src="images/findYuCatResult.png" class="app-screenshot" alt="result for find Yu Cat">
 
@@ -244,43 +345,66 @@ Examples:
 
 Deletes the specified client.
 
-* Deletes the client at the specified `POSITION`.
-* The `POSITION` refers to the `POSITION` number shown in the displayed client list.
+<box type="warning" seamless>
 
-Note: All the pets of the specified client will be deleted too.
+**Warning:** Deleting a client also permanently deletes all of their pets. This cannot be undone.
+
+</box>
 
 Format: `deleteClient POSITION`
 
 Examples:
-* `list` followed by `deleteClient 2` deletes the client with `POSITION` 2 in the displayed list.
-* `find Betsy` followed by `deleteClient 1` deletes the 1st client in the results of the `find` command.
+* `list` followed by `deleteClient 2` — deletes the client at position 2 in the full list.
+* `find Betsy` followed by `deleteClient 1` — deletes the first client in the filtered results.
+
+**Expected output:**
+```
+Deleted Client: Betsy Crowe; Phone: 1234567; Email: betsycrowe@example.com; Address: Crown street; Tags: friend
+```
 
 <br><br>
 
 ### Deleting a pet : `deletePet`
 
-Deletes a pet.
-
-* Deletes the pet at the specified `POSITION`.
-* The `POSITION` refers to the `POSITION` number shown next to the pet.
+Deletes the specified pet.
 
 Format: `deletePet POSITION`
 
-Examples:
-* `deletePet 1`
-
 <box type="info" seamless>
 
-**Note:** Unlike adding pets (which uses owner's phone number), deleting pets uses the global pet position number shown in the list, not the pet's name or owner's phone number.
+**Note:** Pet positions are numbered sequentially across all clients in the list, not per client. For example, if client 1 has 2 pets and client 2 has 1 pet, the pets are at positions 1, 2, and 3 respectively. Always check the current position number before deleting.
+
+Unlike `addPet` (which identifies the owner by phone number), `deletePet` uses the pet's position number shown in the list.
+
 </box>
+
+Examples:
+* `list` followed by `deletePet 2` — deletes the pet at position 2 in the full list.
+* `find Biscuit` followed by `deletePet 1` — deletes the first pet in the filtered results.
+
+**Expected output:**
+```
+Deleted Pet: Biscuit; Species: Dog; Breed: Golden Retriever; Notes: Loves belly rubs; Picture: No picture provided
+```
 
 <br><br>
 
 ### Clearing all records : `clear`
 
-Clears all records from memory. Be careful with this command.
+Deletes all clients and pets from Hairy Pawter.
+
+<box type="warning" seamless>
+
+**Warning:** This permanently deletes every client and pet record. This cannot be undone. Consider [backing up your data file](#editing-the-data-file) before using this command.
+
+</box>
 
 Format: `clear`
+
+**Expected output:**
+```
+Hairy Pawter has been cleared!
+```
 
 <br><br>
 
@@ -295,21 +419,19 @@ Format: `exit`
 
 ## Storing data
 
-
-Data is saved automatically. There is no need to save manually.
+Data is saved automatically after every command. There is no need to save manually.
 
 <br><br>
 
 ### Editing the data file
 
-Data is saved automatically as a JSON file `[hairypawter.jar file location]/data/addressbook.json`.
-It is possible, but not recommended, to update data directly by editing that data file.
+Data is stored as a JSON file at `[hairypawter.jar location]/data/addressbook.json`. You can edit this file directly if needed, but this is not recommended.
 
-<box type="info" seamless>
+<box type="warning" seamless>
 
-**Caution:**
-If your changes to the data file makes its format invalid, the entire file will be discarded the next time the app is opened.  Hence, it is recommended to take a backup of the file before editing it.<br>
-Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+**Caution:** If your edits make the file format invalid, the entire file will be discarded the next time the app opens. Back up the file before editing it.
+
+Certain edits may also cause the app to behave unexpectedly (e.g. if a value is outside the accepted range). Only edit the data file if you are confident you can update it correctly.
 
 </box>
 
@@ -320,56 +442,55 @@ Furthermore, certain edits can cause the app to behave in unexpected ways (e.g.,
 ## FAQ
 
 **Q**: Is it safe to click the close button instead of typing `exit`?<br>
-**A**: Yes.
+**A**: Yes. Your data is saved automatically, so closing the window normally will not result in data loss.
 
 
-**Q**: What should I do if I have clients who do not have a phone?<br>
-**A**: You can put their preferred contact method under `p/PHONE`.
+**Q**: What should I do if a client does not have a phone number?<br>
+**A**: You can enter their preferred contact method (e.g. email address or messaging handle) in the `p/PHONE` field instead.
 
 
 **Q**: How do I reorder my clients?<br>
-**A**: Unfortunately, we do not have a reorder function.
-One way to do this is to close the app and manually reorder the clients in the data file.
+**A**: Reordering is not currently supported. As a workaround, close the app and manually reorder the client entries in the data file at `data/addressbook.json`.
 
 
 **Q**: How do I transfer my data to another computer?<br>
-**A**: Install the app on the other computer and replace the data file on the other computer.
+**A**: Install Hairy Pawter on the other computer, then copy the entire `data/` folder from your current home folder to the same location on the other computer.
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Known issues
 
-1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.
-2. **If you minimize the Help Window** and then run the `help` command (or use the `Help` menu, or the keyboard shortcut `F1`) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.
+1. **When using multiple screens**, if you move the app to a secondary screen and later return to using only the primary screen, the window may open off-screen. Fix: delete the `preferences.json` file in your home folder before restarting the app.
+2. **If you minimise the Help Window** and then run the `help` command again (or press `F1`), the existing minimised window will not reappear and no new window will open. Fix: manually restore the minimised Help Window from your taskbar.
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
 
-Action     | Format, Examples
------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**AddClient** | `addClient p/PHONE [n/NAME] [e/EMAIL] [a/ADDRESS] [t/TAG]…​` <br> e.g., `addClient n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend`
-**AddPet** | `addPet n/NAME p/PHONE​ [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]` <br> e.g., `addPet n/Meowy p/22224444`
-**Clear**  | `clear`
-**DeleteClient** | `deleteClient POSITION`<br> e.g., `deleteClient 3`
-**DeletePet** | `deletePet POSITION`<br> e.g., `deletePet 1`
-**EditClient**   | `editClient POSITION [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editClient 2 n/James Lee e/jameslee@example.com`
-**EditPet**   | `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]`<br> e.g.,`editPet 2 n/Pongo`
-**Exit**   | `exit`
-**Find**   | `find KEYWORD...`<br> e.g., `find James dog`
-**Help**   | `help`
-**List**   | `list`
+Action | Format, Examples
+-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+**[addClient](#adding-a-client-addclient)** | `addClient p/PHONE [n/NAME] [e/EMAIL] [a/ADDRESS] [t/TAG]…​` <br> e.g. `addClient n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend`
+**[addPet](#adding-a-pet-addpet)** | `addPet n/NAME p/PHONE​ [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]` <br> e.g. `addPet n/Meowy p/22224444`
+**[clear](#clearing-all-records-clear)** | `clear`
+**[deleteClient](#deleting-a-client-deleteclient)** | `deleteClient POSITION`<br> e.g. `deleteClient 3`
+**[deletePet](#deleting-a-pet-deletepet)** | `deletePet POSITION`<br> e.g. `deletePet 1`
+**[editClient](#editing-a-client-editclient)** | `editClient POSITION [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g. `editClient 2 n/James Lee e/jameslee@example.com`
+**[editPet](#editing-a-pet-editpet)** | `editPet POSITION [n/NAME] [s/SPECIES] [b/BREED] [nt/NOTES] [pic/PICTURE]`<br> e.g. `editPet 2 n/Pongo`
+**[exit](#exiting-the-app-exit)** | `exit`
+**[find](#locating-clients-and-pets-by-keywords-find)** | `find KEYWORD…`<br> e.g. `find James dog`
+**[help](#viewing-help-help)** | `help`
+**[list](#listing-all-clients-and-pets-list)** | `list`
 
 
 ## Short-form commands
 
-For advanced users, Hairy Pawter supports short-forms for some commands.
+For faster typing, Hairy Pawter supports short-form aliases for the most common commands. Short-forms accept the same parameters as their full equivalents.
 
-| Action         | Short-form |
-|----------------|------------|
-| `AddClient`    | `ac`       |
-| `AddPet`       | `ap`       |
-| `DeleteClient` | `dc`       |
-| `DeletePet`    | `dp`       |
-| `EditClient`   | `ec`       |
-| `EditPet`      | `ep`       |
+| Action | Short-form | Example |
+|--------|------------|---------|
+| `addClient` | `ac` | `ac n/John Doe p/98765432` |
+| `addPet` | `ap` | `ap n/Meowy p/98765432` |
+| `deleteClient` | `dc` | `dc 1` |
+| `deletePet` | `dp` | `dp 2` |
+| `editClient` | `ec` | `ec 1 n/Jane Doe` |
+| `editPet` | `ep` | `ep 1 s/Cat` |

--- a/docs/diagrams/AddPetSequenceDiagram.puml
+++ b/docs/diagrams/AddPetSequenceDiagram.puml
@@ -1,0 +1,79 @@
+@startuml
+!include style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":AddPetCommandParser" as AddPetCommandParser LOGIC_COLOR
+participant "a:AddPetCommand" as AddPetCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant "m:Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("addPet n/Max p/87438807 s/Dog")
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand("addPet n/Max p/87438807 s/Dog")
+activate AddressBookParser
+
+create AddPetCommandParser
+AddressBookParser -> AddPetCommandParser
+activate AddPetCommandParser
+
+AddPetCommandParser --> AddressBookParser
+deactivate AddPetCommandParser
+
+AddressBookParser -> AddPetCommandParser : parse("n/Max p/87438807 s/Dog")
+activate AddPetCommandParser
+
+create AddPetCommand
+AddPetCommandParser -> AddPetCommand
+activate AddPetCommand
+
+AddPetCommand --> AddPetCommandParser :
+deactivate AddPetCommand
+
+AddPetCommandParser --> AddressBookParser : a
+deactivate AddPetCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+AddPetCommandParser -[hidden]-> AddressBookParser
+destroy AddPetCommandParser
+
+AddressBookParser --> LogicManager : a
+deactivate AddressBookParser
+
+LogicManager -> AddPetCommand : execute(m)
+activate AddPetCommand
+
+AddPetCommand -> Model : hasPhone(ownerPhone)
+activate Model
+Model --> AddPetCommand : true
+deactivate Model
+
+AddPetCommand -> Model : hasPet(ownerPhone, pet)
+activate Model
+Model --> AddPetCommand : false
+deactivate Model
+
+AddPetCommand -> Model : addPet(pet, ownerPhone)
+activate Model
+Model --> AddPetCommand
+deactivate Model
+
+create CommandResult
+AddPetCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> AddPetCommand
+deactivate CommandResult
+
+AddPetCommand --> LogicManager : r
+deactivate AddPetCommand
+
+[<-- LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
 - Rewrite product description to be user-centric 
 - Add "Who is this guide for?" 
  - Expand Installation → Quick Start with three subsections: Installation, Overview of the interface (labelled UI table), and a first-session CLI tutorial
  - Define POSITION once in the Commands intro and add a tip box cross-referencing Short-form commands           
  - Add expected output for every command 
  - Replace plain-text warnings with <box type="warning">  for addClient (duplicate phone), addPet (owner must     
  exist, duplicate pet), deleteClient (deletes all pets), clear (irreversible), and the data file caution         
  - Document undocumented constraints: duplicate pet constraint, inability to change a pet's owner via editPet, and pet sequential numbering in deletePet
  - Fix find description: consolidate scattered bullets, add note that result count shows clients not pets       
  - Expand FAQ answers with fuller context (data safety on close, full transfer instructions)                     
  - Fix Known issues wording: "Fix:" label with clearer instructions                                            
  - Fix Command Summary: correct capitalisation (AddClient → addClient), add hyperlinks to all command rows       
  - Improve Short-form commands table: fix capitalisation, add examples column     